### PR TITLE
Add fix_microg script to fix gcm for microg

### DIFF
--- a/res/system/bin/fix_microg
+++ b/res/system/bin/fix_microg
@@ -1,0 +1,32 @@
+#!/system/bin/sh
+# Copyright (C) 2017  frknkrc44
+# This file was created by frknkrc44 (frknkrc44 on GitHub).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version, w/ zip exception.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# This file contains permissions to be granted by default.
+# Default permissions are granted to special platform components and to apps
+# that are approved to get default grants.
+# The special components are apps that are expected to work out-of-the-box
+# as they provide core use cases. These grants are managed by the platform.
+# Fixed permissions cannot be controlled by the user and need a special
+# approval. Typically these are to ensure either legally mandated functions
+# or the app is considered a part of the OS.
+#
+# Granting these permissions could prevent issues on some ROMs or
+# on non-clean installations.
+
+echo "Please wait ..."
+find /data/data -name "com.google.android.gms.*.xml" -exec rm -rf {} \;
+echo "Done!"


### PR DESCRIPTION
if you take backup and change your rom then restore backups, microg can't recognize some apps like WhatsApp. I added a terminal command to fix that