### PR TITLE
KSU fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -81,7 +81,7 @@ echo " - Config says variant $variant";
 echo " ";
 echo " - Copying files...";
 
-for file in "src/META-INF" "INSTALL.md" "LICENSE" "README.md"; do
+for file in "src/META-INF" "src/customize.sh" "INSTALL.md" "LICENSE" "README.md"; do
   [ -e "$workdir/$file" ] || { echo "ERROR: $file doesn't exist"; continue; }
   echo " -- BUILDER: Copying $file";
   cp -Rf "$workdir/$file" "$tmpdir/";

--- a/src/META-INF/com/google/android/update-binary
+++ b/src/META-INF/com/google/android/update-binary
@@ -15,6 +15,7 @@ zipfile="$3";
 
 ps | grep zygote | grep -v grep >/dev/null && bootmode=true || bootmode=false;
 $bootmode || ps -A 2>/dev/null | grep zygote | grep -v grep >/dev/null && bootmode=true;
+${BOOTMODE:-false} && bootmode=true;
 
 if $bootmode; then
   ui_print() {
@@ -147,7 +148,7 @@ $bootmode || {
 
 bbdir="/tmp/busybox";
 $bootmode || {
-  for bb in /data/adb/magisk/busybox; do
+  for bb in /data/adb/ksu/bin/busybox /data/adb/magisk/busybox; do
     [ -f "$bb" ] && magiskbb="$bb";
   done;
   [ "$magiskbb" ] && {
@@ -164,7 +165,7 @@ for bin in chcon chmod chown cp cut df du echo find grep head mkdir mount ps rm 
   command -v "$bin" >/dev/null || abort "No $bin available";
 done;
 
-$bootmode && filedir="/dev/tmp/$modname" || filedir="/tmp/$modname";
+$bootmode && filedir="${TMPDIR:-/dev/tmp}/$modname" || filedir="/tmp/$modname";
 tmplibdir="$filedir/tmplibdir";
 
 $bootmode && forcesys=no;
@@ -470,7 +471,12 @@ fi;
 
 ui_print " ";
 ui_print "Mounting...";
-if [ -e "/data/adb/magisk" ] && [ "$forcesys" != "yes" ]; then
+if $bootmode && ${KSU:-false}; then
+  rootpart="/data";
+  modulesdir="${MODPATH%/*}";
+  root="${MODPATH}";
+  magisk=yes;
+elif [ -e "/data/adb/magisk" ] && [ "$forcesys" != "yes" ]; then
   rootpart="/data";
   $bootmode && modulesdir="$rootpart/adb/modules_update" || modulesdir="$rootpart/adb/modules";
   root="$modulesdir/$modname";

--- a/src/customize.sh
+++ b/src/customize.sh
@@ -1,0 +1,7 @@
+#!/system/bin/sh
+export KSU KSU_VER KSU_VER_CODE MAGISK_VER MAGISK_VER_CODE BOOTMODE MODPATH TMPDIR ZIPFILE ARCH IS64BIT API;
+SKIPUNZIP=1;
+modname="MinMicroG";
+mkdir -p "$TMPDIR/$modname";
+unzip -qj "$ZIPFILE" defconf META-INF/com/google/android/update-binary -d "$TMPDIR/$modname";
+sh "$TMPDIR/$modname/update-binary" '' '' "$ZIPFILE";


### PR DESCRIPTION
Fixes µG permissions and library unpacking by leveraging huge similarities between Magisk's and KernelSU's installation processes. Unfortunately, KSU doesn't use `update-binary`, but rather `customize.sh` instead, so I had to copy the script over while working on deduplicating this code in a manner working with systemized, Magisk and KernelSU installs at the same time.